### PR TITLE
Fixing numerical issues with Gravity & Pressure

### DIFF
--- a/Assets/Scenes/SimScene.unity
+++ b/Assets/Scenes/SimScene.unity
@@ -275,9 +275,9 @@ MonoBehaviour:
   mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
   material: {fileID: 2100000, guid: 2c651728f668a534c808e18d92c51fd8, type: 2}
   count: 1000
-  particleRadius: 1
-  radius: 3
-  totalMass: 1000
+  particleRadius: 10
+  radius: 10
+  totalMass: 10
 --- !u!135 &948306070
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Systems/GravityFieldSystem.cs
+++ b/Assets/Scripts/Systems/GravityFieldSystem.cs
@@ -93,8 +93,8 @@ public class GravityFieldSystem : SystemBase
                         grav_potential = -(m / r);
                     }
 
-                    float3 grav_field = displacement * ( - grav_mag_over_r );
-                    gravity += new float4(gravConstant * grav_field, gravConstant * grav_potential);
+                    float3 grav_potential_gradient = displacement * grav_mag_over_r;
+                    gravity += new float4(gravConstant * grav_potential_gradient, gravConstant * grav_potential);
                 }
 
                 grav_i.Value = gravity;

--- a/Assets/Scripts/Systems/ParticleAuthoring.cs
+++ b/Assets/Scripts/Systems/ParticleAuthoring.cs
@@ -157,8 +157,8 @@ public class ParticleAuthoring : MonoBehaviour, IConvertGameObjectToEntity
             using (var rng = rngFactory.GetRng())
             {
                 position = center + RandomFloat3WithinSphere(rng, radius);
-                particleVelocity = RandomFloat3WithinSphere(rng, 1.0f);
-                //particleVelocity = float3.zero;
+                //particleVelocity = RandomFloat3WithinSphere(rng, 1.0f);
+                particleVelocity = float3.zero;
                 baseColor = new float4(rng.NextFloat3(1.0f), 0);
             }
 

--- a/Assets/Scripts/Systems/PressureFieldSystem.cs
+++ b/Assets/Scripts/Systems/PressureFieldSystem.cs
@@ -28,7 +28,7 @@ public class PressureFieldSystem : SystemBase
         // K = 1 for now, but a physically realistic value is K = 2.6*10^12 dyne*cm^4/g^2
         
         Entities.ForEach((ref ParticlePressure pressure_i, in ParticleDensity density_i) => {
-            float K = 1.0f;
+            float K = 1000.0f;
             float pressure = K * density_i.Value * density_i.Value;
             pressure_i.Value = pressure; 
         }).ScheduleParallel();

--- a/Assets/Scripts/Util/SplineKernel.cs
+++ b/Assets/Scripts/Util/SplineKernel.cs
@@ -101,7 +101,7 @@ static class SplineKernel
         float3 kernel_deriv = displacement * ( KernelDeriv(distance, size) / distance);
         float kernel = Kernel(distance, size);
 
-        return new float4(displacement * kernel_deriv, kernel);
+        return new float4(kernel_deriv, kernel);
     }
 
     // Derivative of the kernel with respect to distance argument.


### PR DESCRIPTION
Now possible to have 2 particles fall and repel. Not hydrostatic equilibrium yet
- Disabled initial velocity for particles
- Fixed: Now storing gravitational field as simply Del(Potential)
- Fixed: Kernel was double-multiplying displacement vector
         resulting in sign and scale errors in Del(W).