### PR TITLE
Rewrite Kernel System to use Broadphase Results Directly

### DIFF
--- a/Assets/Scripts/Components/Kernel.cs
+++ b/Assets/Scripts/Components/Kernel.cs
@@ -2,14 +2,16 @@ using Unity.Entities;
 using Unity.Mathematics;
 
 // TODO: how many should we keep on-chunk before we dynamically allocate?
-[InternalBufferCapacity(8)]
+[InternalBufferCapacity(50)]
 public struct ParticleInteraction : IBufferElementData
 {
-    public Entity Self; // Only needed for intermediate queue, could be factored out
     public Entity Other;
     public float4 KernelThis; // w = W(r_i-r_j,h_i) xyz = Del_i W(r_i-r_j,h_i)
-    public float4 KernelOther; // w = W(r_i-r_j, h_j) xyz = Del_i W(r_i-r_j,h_j)
     public float4 KernelSymmetric; // 1/2 (Kernel + KernelOther)
+#if DEBUG_KERNEL
+    public float4 KernelOther; // w = W(r_i-r_j, h_j) xyz = Del_i W(r_i-r_j,h_j)
+    public Entity Self; // Only needed for intermediate queue, could be factored out
     public float distance;
+#endif
 }
 

--- a/Assets/Scripts/Components/Kernel.cs
+++ b/Assets/Scripts/Components/Kernel.cs
@@ -5,6 +5,7 @@ using Unity.Mathematics;
 [InternalBufferCapacity(8)]
 public struct ParticleInteraction : IBufferElementData
 {
+    public Entity Self; // Only needed for intermediate queue, could be factored out
     public Entity Other;
     public float4 KernelThis; // w = W(r_i-r_j,h_i) xyz = Del_i W(r_i-r_j,h_i)
     public float4 KernelOther; // w = W(r_i-r_j, h_j) xyz = Del_i W(r_i-r_j,h_j)

--- a/Assets/Scripts/Systems/DensityFieldSystem.cs
+++ b/Assets/Scripts/Systems/DensityFieldSystem.cs
@@ -7,7 +7,7 @@ using Unity.Burst;
 [BurstCompile]
 [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
 [UpdateAfter(typeof(StepPhysicsWorld))]
-public class DensityFieldSystem : SystemBase, IParticleSystem
+public class DensityFieldSystem : SystemBase, IPhysicsSystem
 {
     public void AddInputDependency(JobHandle jh)
     {

--- a/Assets/Scripts/Systems/DensityFieldSystem.cs
+++ b/Assets/Scripts/Systems/DensityFieldSystem.cs
@@ -6,7 +6,7 @@ using Unity.Burst;
 
 [BurstCompile]
 [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
-[UpdateAfter(typeof(KernelDataSystem))]
+[UpdateAfter(typeof(StepPhysicsWorld))]
 public class DensityFieldSystem : SystemBase, IParticleSystem
 {
     public void AddInputDependency(JobHandle jh)

--- a/Assets/Scripts/Systems/KernelSystem.cs
+++ b/Assets/Scripts/Systems/KernelSystem.cs
@@ -165,8 +165,6 @@ public class KernelSystem : SystemBase, IParticleSystem
            { 
                 int batchCount = 1; // How many interaction pairs should a worker process before returning to the pool?
 
-
-
                // Job to create an appropriately sized list of NativeQueues
 
                // Hijack the indexing scheme used in physics for ordering rigid bodies
@@ -176,15 +174,7 @@ public class KernelSystem : SystemBase, IParticleSystem
                NativeStream particleInteractions = new NativeStream(numParticles, Allocator.TempJob);
 
                // Job to evaluate kernel across and push into native queues
-               // Try Get sim.StepContext.PhasedDispatchPais with reflection
-               // This is an internal array in the physics system of object pairs from the broadphase.
-               // We need this array to distribute processing of pairs across threads
-               // What we are doing is essentially an IBodyPairsJob, but multithreaded
-               // It is too bad there is no interface for this in Physics
-               var stepContextFieldInfo = sim.GetType().GetField("StepContext", BindingFlags.NonPublic | BindingFlags.Instance);
-               var stepContext = stepContextFieldInfo.GetValue(sim);
-               var phasedDispatchPairsFieldInfo = stepContext.GetType().GetField("PhasedDispatchPairs", BindingFlags.Public | BindingFlags.Instance);
-               var phasedDispatchPairs = (NativeList<DispatchPairSequencer.DispatchPair>)phasedDispatchPairsFieldInfo.GetValue(stepContext);
+                NativeList<DispatchPairSequencer.DispatchPair> phasedDispatchPairs = ((Simulation)sim).StepContext.PhasedDispatchPairs;
 
                // Also need the solver scheduler info so we can iterate over body pairs multithreaded (similar to solver)
                var solverSchedulerInfoFieldInfo = stepContext.GetType().GetField("SolverSchedulerInfo", BindingFlags.Public | BindingFlags.Instance);

--- a/Assets/Scripts/Systems/KernelSystem.cs
+++ b/Assets/Scripts/Systems/KernelSystem.cs
@@ -1,9 +1,3 @@
-#define LIST_OF_QUEUES
-//#define COMMAND_BUFFER
-//#define RECORD_ALL_COLLISIONS 
-// Debug flag to help understand what is being detected as
-// a collision in simple situations, verify correctness
-
 using System;
 using UnityEngine;
 using Unity.Entities;
@@ -18,30 +12,11 @@ using Unity.Collections.LowLevel.Unsafe;
 using static Unity.Physics.DispatchPairSequencer;
 using UnityEngine.Assertions;
 
-#if RECORD_ALL_COLLISIONS
-[InternalBufferCapacity(8)]
-public struct ParticleCollision : IBufferElementData
-{
-    public Entity Other;
-    public float distance;
-}
-#endif
-
-// Copied from IPhysicsSystem because this is a good idea generally
-// for systems that have to run in-order repeatedly and handle their
-// own data structure cleanup
-interface IParticleSystem
-{
-    void AddInputDependency(JobHandle inputDep);
-
-    JobHandle GetOutputDependency();
-}
-
 [BurstCompile]
 [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
 [UpdateAfter(typeof(BuildPhysicsWorld))]
 [UpdateBefore(typeof(StepPhysicsWorld))]
-public class KernelSystem : SystemBase, IParticleSystem
+public class KernelSystem : SystemBase, IPhysicsSystem
 {
     private StepPhysicsWorld m_StepPhysicsWorld;
     private NativeStream m_interactions;
@@ -51,7 +26,6 @@ public class KernelSystem : SystemBase, IParticleSystem
 
     // If you need to use the interaction data, register yourself so we 
     // wait for you to finish
-    // TODO modify this and callers after IPhysicsJob
     public void AddInputDependency(JobHandle jh)
     {
         inputDependency = JobHandle.CombineDependencies(jh, inputDependency);
@@ -89,20 +63,10 @@ public class KernelSystem : SystemBase, IParticleSystem
         {
             var particleCount = 0;
             var interactionCount = 0;
-#if RECORD_ALL_COLLISIONS
-            var collisionCount = 0;
-#endif
             // Block the main thread until completion here
-            Entities.ForEach((in DynamicBuffer<ParticleInteraction> interactions
-#if RECORD_ALL_COLLISIONS
-                ,in DynamicBuffer < ParticleCollision > collisions
-#endif
-                ) =>
+            Entities.ForEach((in DynamicBuffer<ParticleInteraction> interactions) =>
             {
                 interactionCount += interactions.Length;
-#if RECORD_ALL_COLLISIONS
-                collisionCount += collisions.Length;
-#endif
                 particleCount += 1;
             }).Run();
 
@@ -110,28 +74,18 @@ public class KernelSystem : SystemBase, IParticleSystem
             Debug.Log("Interaction Pairs: " + interactionCount.ToString());
             Debug.Log("Particle count: " + particleCount.ToString());
             Debug.Log("Avg interactions per particle: " + (interactionCount / particleCount).ToString());
-#if RECORD_ALL_COLLISIONS
-            Debug.Log("Collision Pairs: " + collisionCount.ToString());
-            Debug.Log("Avg collisions per particle: " + (collisionCount / particleCount).ToString());
-#endif
         }
 
         // Go over every particle and remove all the kernel contributions.
         // On the main thread of course!
         // This is not as bad as it seems, because Clear leaves memory capacity allocated.
-        Entities.ForEach((ref DynamicBuffer<ParticleInteraction> interactions
-#if RECORD_ALL_COLLISIONS
-            ,ref DynamicBuffer<ParticleCollision> collisions
-#endif
-            ) =>
+        Entities.ForEach((ref DynamicBuffer<ParticleInteraction> interactions) =>
         {
             interactions.Clear();
-#if RECORD_ALL_COLLISIONS
-            collisions.Clear();
-#endif
         }).Run();
 
-        if (m_interactions.IsCreated) {
+        if (m_interactions.IsCreated)
+        {
             m_interactions.Dispose();
         }
 
@@ -142,8 +96,8 @@ public class KernelSystem : SystemBase, IParticleSystem
     unsafe protected override void OnUpdate()
     {
         Cleanup();
-#if true
-        m_StepPhysicsWorld.EnqueueCallback(SimulationCallbacks.Phase.PostBroadphase, 
+
+        m_StepPhysicsWorld.EnqueueCallback(SimulationCallbacks.Phase.PostBroadphase,
             (ref ISimulation sim, ref PhysicsWorld pw, JobHandle inputDeps) =>
             {
                 // A little paranoid since we're a custom callback that only exists in modified unity physics
@@ -221,12 +175,12 @@ public class KernelSystem : SystemBase, IParticleSystem
                 Assert.AreNotEqual(numBodies, 0);
                 JobHandle sortedByBodyAPairsHandle = ScheduleSortPairsJob(true, unsortedPairs, numBodies,
                     out NativeList<DispatchPair> sortedByBodyAPairs,
-                    out NativeList<int> bodyAOffsets, 
+                    out NativeList<int> bodyAOffsets,
                     inputDeps);
 
                 JobHandle sortedByBodyBPairsHandle = ScheduleSortPairsJob(false, unsortedPairs, numBodies,
                     out NativeList<DispatchPair> sortedByBodyBPairs,
-                    out NativeList<int> bodyBOffsets, 
+                    out NativeList<int> bodyBOffsets,
                     inputDeps);
 
                 inputDeps = JobHandle.CombineDependencies(sortedByBodyAPairsHandle, sortedByBodyBPairsHandle);
@@ -235,7 +189,7 @@ public class KernelSystem : SystemBase, IParticleSystem
                 // Multithreading is per-particle, so we can immediately write the particle's DynamicBuffer component
                 inputDeps = ScheduleCalculateInteractionJob(
                     ref sortedByBodyAPairs, ref sortedByBodyBPairs,
-                    ref bodyAOffsets, ref bodyBOffsets, 
+                    ref bodyAOffsets, ref bodyBOffsets,
                     pw.Bodies,
                     GetComponentDataFromEntity<ParticleSmoothing>(true),
                     GetComponentDataFromEntity<Translation>(true),
@@ -262,56 +216,14 @@ public class KernelSystem : SystemBase, IParticleSystem
                 outputDependency = scheduledJobHandle;
                 return scheduledJobHandle;
             }, Dependency);
-#else
-                m_StepPhysicsWorld.EnqueueCallback( SimulationCallbacks.Phase.PostCreateDispatchPairs,
-            (ref ISimulation sim, ref PhysicsWorld pw, JobHandle inputDeps) =>
-            {
-
-                // Throw if we can't have unity Physics, we rely on unity physics internal data structures
-                if (sim.Type != SimulationType.UnityPhysics)
-                {
-                    throw new NotImplementedException("SPH KernelSystem Only works with Unity Physics");
-                }
-                var stepContext = ((Simulation)sim).StepContext;
-                var phasedDispatchPairs = stepContext.PhasedDispatchPairs;
-                var solverSchedulerInfo = stepContext.SolverSchedulerInfo;
-
-                NativeArray<int> numWorkItems = solverSchedulerInfo.NumWorkItems;
-
-                inputDeps = NativeStream.ScheduleConstruct(out m_interactions, numWorkItems, inputDeps, Allocator.TempJob);
-
-                // Job to evaluate kernel across all interaction pairs and push into native queues
-                int batchCount = 1; // How many interaction pairs should a worker process before returning to the pool?
-                var capturePairsTest = new InteractionPairsJob()
-                {
-                    phasedDispatchPairs = phasedDispatchPairs.AsDeferredJobArray(),
-                    bodies = pw.Bodies,
-                    smoothingData = GetComponentDataFromEntity<ParticleSmoothing>(true), // RO access to particle smoothing size
-                    translationData = GetComponentDataFromEntity<Translation>(true),
-                    interactionsWriter = m_interactions.AsWriter(),
-                    SolverSchedulerInfo = solverSchedulerInfo,
-                };
-                inputDeps = capturePairsTest.ScheduleUnsafeIndex0(numWorkItems, batchCount, inputDeps);
-                // Job to disable further physics calculation on our pairs
-                var disablePairs = new DisablePairsJob();
-                inputDeps = disablePairs.Schedule(sim, ref pw, inputDeps);
-                // Iterate multithreaded over m_interactions and copy to particle
-                // dynamic buffer components
-                inputDeps = ScheduleCopyInteractionJob(ref m_interactions, ref solverSchedulerInfo,
-                    GetBufferFromEntity<ParticleInteraction>(), 
-                    inputDeps);
-                var scheduledJobHandle = JobHandle.CombineDependencies(inputDeps, Dependency);
-                outputDependency = scheduledJobHandle;
-                return scheduledJobHandle;
-           }, Dependency);
-#endif
-           updateNumber++;
+        updateNumber++;
     }
 
+    #region Kernel Calculation
     private JobHandle ScheduleCalculateInteractionJob(
-        ref NativeList<DispatchPair> sortedByBodyAPairs, 
-        ref NativeList<DispatchPair> sortedByBodyBPairs, 
-        ref NativeList<int> bodyAOffsets, 
+        ref NativeList<DispatchPair> sortedByBodyAPairs,
+        ref NativeList<DispatchPair> sortedByBodyBPairs,
+        ref NativeList<int> bodyAOffsets,
         ref NativeList<int> bodyBOffsets,
         NativeArray<RigidBody> bodies,
         ComponentDataFromEntity<ParticleSmoothing> smoothingData,
@@ -357,19 +269,20 @@ public class KernelSystem : SystemBase, IParticleSystem
             Assert.AreEqual(SortedByBodyAPairs.Length, SortedByBodyBPairs.Length);
             Assert.AreNotEqual(SortedByBodyAPairs.Length, 0);
             Entity i = Bodies[bodyIndex].Entity;
-            if( ! BufferLookup.HasComponent(i) || 
-                ! SmoothingData.HasComponent(i) || 
-                ! TranslationData.HasComponent(i) ) {
+            if (!BufferLookup.HasComponent(i) ||
+                !SmoothingData.HasComponent(i) ||
+                !TranslationData.HasComponent(i))
+            {
                 // Debug.Log("Found weird Entity " + i.Index + " RigidBody Index: " + bodyIndex);
                 return;
             }
             DynamicBuffer<ParticleInteraction> buffer = BufferLookup[i];
 
             //insert interactions where this body was first
-            int BodyAPastEndOffset = ((bodyIndex + 1) < BodyAOffsets.Length) ? 
+            int BodyAPastEndOffset = ((bodyIndex + 1) < BodyAOffsets.Length) ?
                 BodyAOffsets[bodyIndex + 1] : SortedByBodyAPairs.Length;
             int BodyAStartOffset = BodyAOffsets[bodyIndex];
-            for( int index = BodyAStartOffset; index < BodyAPastEndOffset; index++)
+            for (int index = BodyAStartOffset; index < BodyAPastEndOffset; index++)
             {
                 Entity j = Bodies[SortedByBodyAPairs[index].BodyIndexB].Entity;
                 ParticleInteraction interaction = CalculateInteraction(i, j);
@@ -393,13 +306,29 @@ public class KernelSystem : SystemBase, IParticleSystem
                 }
             }
         }
+
+        // TODO: Memoize this every frame. We are guaranted to call CalculateInteraction 2x,
+        //       once for i->j and once for j->i
+        //
+        //       The contributions differ by a minus sign in the gradient, so a lookup of either
+        //       may be faster than recalculating.
+        //
+        //       One way: Use three arrays
+        //       1) Array of ParticleInteraction indexed by unsorted pair index
+        //       2) Array that goes from sorted-by-a index -> unsorted index 
+        //       3) Array that goes from sorted-by-b index -> unsorted index
+        //       2 & 3 are easy/fast to make from information available during sorting job.
+        //
+        //       Might be better cache-wise with two arrays:
+        //       1) Array of ParticleInteraction indexed by sorted-by-a index  (a-sorted pass lookup directly here)
+        //       2) Array that goes from sorted-by-a index -> sorted-by-b index (How do you make this array easily?)
         public ParticleInteraction CalculateInteraction(Entity i, Entity j)
         {
             var r_i = TranslationData[i].Value;
             var r_j = TranslationData[j].Value;
-
+#if DEBUG_KERNEL
             var distance = math.length(r_i - r_j);
-
+#endif
             // Calculate symmetrized kernel contribution.
             // Once for derivatives w.r.t. particle i position, again for derivitives w.r.t. particle j
             // TODO: There is some duplicaiton of effort here especially on the kernel values
@@ -412,20 +341,24 @@ public class KernelSystem : SystemBase, IParticleSystem
             var kernel_ij_sym = (kernel_ij_i + kernel_ij_j) * 0.5f;
             var ij = new ParticleInteraction
             {
-                Self = i,
                 Other = j,
                 KernelThis = kernel_ij_i,
-                KernelOther = kernel_ij_j,
                 KernelSymmetric = kernel_ij_sym,
+#if DEBUG_KERNEL
+                KernelOther = kernel_ij_j,
+                Self = i,
                 distance = distance,
+#endif
             };
             return ij;
         }
     }
+#endregion
 
-    private static JobHandle ScheduleSortPairsJob(bool bodyAIsKey, NativeList<DispatchPair> unsortedPairs, 
-        int numBodies, 
-        out NativeList<DispatchPair> sortedPairs, 
+#region Sorting
+    private static JobHandle ScheduleSortPairsJob(bool bodyAIsKey, NativeList<DispatchPair> unsortedPairs,
+        int numBodies,
+        out NativeList<DispatchPair> sortedPairs,
         out NativeList<int> bodyOffsets,
         JobHandle handle, bool singleThread = true)
     {
@@ -468,7 +401,7 @@ public class KernelSystem : SystemBase, IParticleSystem
                 BodyOffsets = bodyOffsets,
                 BodyLengths = bodyLengths,
                 NumBodies = numBodies,
-            }; 
+            };
             handle = generateOffsets.Schedule(handle);
 
             var sortJob = new SortPairsJob
@@ -515,7 +448,7 @@ public class KernelSystem : SystemBase, IParticleSystem
 
             Assert.AreEqual(UnsortedPairs.Length, SortedPairs.Length);
             Assert.AreEqual(NumBodies, BodyOffsets.Length);
-            
+
             // I think this is unnecessary to check because of a quirk in NativeArray
             //Assert.AreEqual(NumBodies, BodyLengths.Length);
             // Count the bodies by index
@@ -548,9 +481,9 @@ public class KernelSystem : SystemBase, IParticleSystem
             }
         }
     }
-
+#region Multithreaded Sorting
     [BurstCompile]
-    public struct SortPairsJob: IJobParallelForDefer
+    public struct SortPairsJob : IJobParallelForDefer
     {
         // Input
         [ReadOnly] public bool BodyAIsKey;
@@ -559,15 +492,15 @@ public class KernelSystem : SystemBase, IParticleSystem
 
         // Output
         [NativeDisableParallelForRestriction]
-        public NativeList <DispatchPair> SortedPairs;
+        public NativeList<DispatchPair> SortedPairs;
         public void Execute(int bodyIndex)
         {
             // Lookup offset in body index
             int offset = BodyOffsets[bodyIndex];
-            
+
             // Go across entire unsorted body pairs array looking for our particle
             // Copy to appropriate location in sorted pairs array
-            for (int i = 0; i< UnsortedPairs.Length; i++)
+            for (int i = 0; i < UnsortedPairs.Length; i++)
             {
                 var key = BodyAIsKey ? UnsortedPairs[i].BodyIndexA : UnsortedPairs[i].BodyIndexB;
                 if (key == bodyIndex)
@@ -581,7 +514,7 @@ public class KernelSystem : SystemBase, IParticleSystem
 
     [NoAlias]
     [BurstCompile]
-    public struct GenerateOffsetsJob: IJob
+    public struct GenerateOffsetsJob : IJob
     {
         // In
         [ReadOnly] public bool BodyAIsKey;  // True if we're using body A as key
@@ -595,7 +528,7 @@ public class KernelSystem : SystemBase, IParticleSystem
         public NativeList<int> BodyOffsets;
         public NativeArray<int> BodyLengths;
 
-        public void Execute() 
+        public void Execute()
         {
             SortedPairs.ResizeUninitialized(UnsortedPairs.Length);
             BodyOffsets.ResizeUninitialized(NumBodies);
@@ -604,7 +537,7 @@ public class KernelSystem : SystemBase, IParticleSystem
             {
                 var pair = UnsortedPairs[i];
                 var bodyIndex = BodyAIsKey ? pair.BodyIndexA : pair.BodyIndexB;
-                BodyLengths[bodyIndex] += 1;                
+                BodyLengths[bodyIndex] += 1;
             }
 
             // Calculate offsets in a sorted array
@@ -616,7 +549,10 @@ public class KernelSystem : SystemBase, IParticleSystem
             }
         }
     }
+#endregion
+#endregion
 
+#region Flatten Filter Jobs
     // Run over the For-Each index of the nativeStream counting elements
     // Put the cumulative element counts into an array
     [BurstCompile]
@@ -633,7 +569,7 @@ public class KernelSystem : SystemBase, IParticleSystem
         // Output
         // Array offsets indexed by the foreach index of DynamicVsDynamicPairs
         public NativeList<int> ElementOffsets;
-        
+
 
         public void Execute()
         {
@@ -665,7 +601,7 @@ public class KernelSystem : SystemBase, IParticleSystem
     {
         // Input
         [ReadOnly] public NativeStream Stream;
-        
+
         // Output
         public NativeArray<int> ForEachCount0;
 
@@ -706,7 +642,7 @@ public class KernelSystem : SystemBase, IParticleSystem
                 Entity entityA = Bodies[bodyIndexPair.BodyIndexA].Entity;
                 Entity entityB = Bodies[bodyIndexPair.BodyIndexB].Entity;
 
-                if( SmoothingData.HasComponent(entityA) && SmoothingData.HasComponent(entityB))
+                if (SmoothingData.HasComponent(entityA) && SmoothingData.HasComponent(entityB))
                 {
                     var r_i = TranslationData[entityA].Value;
                     var r_j = TranslationData[entityB].Value;
@@ -718,8 +654,8 @@ public class KernelSystem : SystemBase, IParticleSystem
                         // This particle has nonzero neighbor interaction
                         ParticleBodyPairsWriter.Write(bodyIndexPair);
                     }
-                } 
-                else 
+                }
+                else
                 {
                     // Not ours, output to the list physics will consume
                     PhysicsBodyPairsWriter.Write(bodyIndexPair);
@@ -749,9 +685,9 @@ public class KernelSystem : SystemBase, IParticleSystem
         {
             var offset = ElementOffsets[forEachIndex];
             var reader = DynamicVsDynamicPairs.AsReader();
-         
+
             reader.BeginForEachIndex(forEachIndex);
-            while(reader.RemainingItemCount > 0)
+            while (reader.RemainingItemCount > 0)
             {
                 DispatchPair pair = DispatchPair.CreateCollisionPair(reader.Read<BodyIndexPair>());
                 UnsortedPairs[offset] = pair;
@@ -760,227 +696,6 @@ public class KernelSystem : SystemBase, IParticleSystem
             reader.EndForEachIndex();
         }
     }
+#endregion
 
-    // Copying the pattern of the Jacobian solver which also needs to write
-    // A per-body array of Motions. Our version is appending to a dynamic component
-    // But the requirement that we be able to only have a single concurrent thread
-    // accessing a body is the same.
-    //
-    // How this works:
-    // Within a Phase, a body appearing in one work item means all of its interactions
-    // wil be in the same work batch. 
-    // 
-    // By default, the physics scheduler uses a batch size of 8 interactions and 16 phases. 
-    // The last phase is special and has to be run single-threaded. When the number of 
-    // interactions per particle exceeds 8*15=120 we begin to spill over into this special phase
-    // and losing speedup from multithreading.
-    //
-    // Physics is doing a masking calculation to choose which phase a body goes in. That masking
-    // uses the bits of a ushort. This makes sense in the context of most games where
-    // high-collisions-per-dynamic-body is atypical. 
-    //
-    // If you are running into the limit with collisions, the simplest way forward is to increase
-    // the batch size. Unfortunately, with a dense graph of collisions each phase gets dominated
-    // by a small number of particles. This means increasing the batch size still results in most
-    // collisions being sorted to the single threaded final phase.
-    //
-    // TL;DR: This does not achieve a multithreaded speedup. What is needed is a way to iterate
-    // over the collisions per-particle, and have each thread only work on a single particle.
-    
-    internal static unsafe JobHandle ScheduleCopyInteractionJob(
-        ref NativeStream interactions,
-        ref DispatchPairSequencer.SolverSchedulerInfo solverSchedulerInfo,
-        BufferFromEntity<ParticleInteraction> bufferLookup,
-        JobHandle inputDeps)
-    {
-        JobHandle handle = inputDeps;
-        int numPhases = solverSchedulerInfo.NumPhases;
-
-        var phaseInfoPtrs = (DispatchPairSequencer.SolverSchedulerInfo.SolvePhaseInfo*) 
-            NativeArrayUnsafeUtility.GetUnsafeBufferPointerWithoutChecks(solverSchedulerInfo.PhaseInfo);
-
-        for (int phaseId = 0; phaseId < numPhases; phaseId++)
-        {
-            var copyInteractionJob = new CopyInteractionJob()
-            {
-                interactionsReader = interactions.AsReader(),
-                bufferLookup = bufferLookup,
-                PhaseIndex = phaseId,
-                Phases = solverSchedulerInfo.PhaseInfo,
-            };
-
-            // NOTE: The last phase must be executed on a single job since 
-            //       The last phase is were the sorting algorithm dumps all dispatch
-            //       pairs that have been fully excluded from other phases
-            // Copying use of int.MaxValue/2 from similar physics code (ScheduleSolveJacobiansJobs) in Solver.cs
-            bool isLastPhase = phaseId == numPhases - 1;
-            int batchSize = isLastPhase ? (int.MaxValue / 2) : 1;
-
-            int* numWorkItems = &(phaseInfoPtrs[phaseId].NumWorkItems);
-            handle = copyInteractionJob.Schedule(numWorkItems, batchSize, handle);
-        }
-
-        return handle;
-    }
-    
-    // This job nerfs future physics on any interaction pair identified in 
-    // Broadphase which we will be computing. Operates in concert with InteractionPairsJob
-    [BurstCompile]
-    public struct DisablePairsJob : IBodyPairsJob
-    {
-        public void Execute(ref ModifiableBodyPair triggerEvent)
-        {
-            // TODO: Filter object interactions so we only operate on particles
-
-            triggerEvent.Disable();
-            // Stop physics from doing more with this collision!
-            // no jacobians! No collision response!
-            // only step-velocity integration!
-        }
-    }
-
-    [NoAlias]
-    [BurstCompile]
-    public struct CopyInteractionJob : IJobParallelForDefer
-    {
-        [ReadOnly, NoAlias] public NativeStream.Reader interactionsReader;
-
-        [NativeDisableParallelForRestriction]
-        public BufferFromEntity<ParticleInteraction> bufferLookup;
-
-        [ReadOnly, NoAlias] public NativeArray<DispatchPairSequencer.SolverSchedulerInfo.SolvePhaseInfo> Phases;
-        public int PhaseIndex;
-
-        public void Execute(int workItemIndex)
-        {
-            int workItemStartIndexOffset = Phases[PhaseIndex].FirstWorkItemIndex;
-            ExecuteImpl(workItemIndex + workItemStartIndexOffset);
-        }
-
-        public void ExecuteImpl(int workItemIndex)
-        {
-            interactionsReader.BeginForEachIndex(workItemIndex);
-            while(interactionsReader.RemainingItemCount > 0)
-            {
-                ParticleInteraction interaction = interactionsReader.Read<ParticleInteraction>();
-                DynamicBuffer<ParticleInteraction> buffer = bufferLookup[interaction.Self];
-                /*
-                Debug.Log(workItemIndex + " " +
-                    interaction.Self.Index + " " +
-                    interaction.Other.Index + " " + 
-                    interaction.distance);
-                */
-                buffer.Add(interaction);
-            }
-            interactionsReader.EndForEachIndex();
-        }
-    }
-
-    
-    
-    
-    [BurstCompile]
-    [NoAlias]
-    public struct InteractionPairsJob : IJobParallelForDefer
-    {
-        [ReadOnly, NoAlias] public NativeArray<DispatchPairSequencer.DispatchPair> phasedDispatchPairs;
-
-        [ReadOnly, NoAlias] public NativeArray<RigidBody> bodies;
-        [ReadOnly] public ComponentDataFromEntity<ParticleSmoothing> smoothingData;
-        [ReadOnly] public ComponentDataFromEntity<Translation> translationData;
-        [ReadOnly, NoAlias] public DispatchPairSequencer.SolverSchedulerInfo SolverSchedulerInfo;
-        [WriteOnly, NoAlias] public NativeStream.Writer interactionsWriter;
-
-        public void Execute(int workItemIndex)
-        {
-            int dispatchPairReadOffset = SolverSchedulerInfo.GetWorkItemReadOffset(workItemIndex, out int numPairsToRead);
-            interactionsWriter.BeginForEachIndex(workItemIndex);
-
-            ExecuteImpl(dispatchPairReadOffset, numPairsToRead);
-
-            interactionsWriter.EndForEachIndex();
-        }
-        public void ExecuteImpl(int dispatchPairReadOffset, int numPairsToRead)
-        {
-            for (int index = 0; index < numPairsToRead; index++)
-            {
-                DispatchPairSequencer.DispatchPair dispatchPair = phasedDispatchPairs[dispatchPairReadOffset + index];
-                // Skip joint pairs and invalid pairs
-                if (dispatchPair.IsJoint || !dispatchPair.IsValid)
-                {
-                    return;
-                }
-
-                Entity i = bodies[dispatchPair.BodyIndexA].Entity;
-                Entity j = bodies[dispatchPair.BodyIndexB].Entity;
-
-                var r_i = translationData[i].Value;
-                var r_j = translationData[j].Value;
-
-                var distance = math.length(r_i - r_j);
-
-                // Calculate symmetrized kernel contribution.
-                // Once for derivatives w.r.t. particle i position, again for derivitives w.r.t. particle j
-                // TODO: There is some duplicaiton of effort here especially on the kernel values
-                // TODO: It is possible to reject pairs before performing this calculation
-
-                // Derivatives are implicitly w.r.t to particle i position.
-                // therefore the "symmetrized" kernel still has a preferred index in the derivative
-                float4 kernel_ij_i = SplineKernel.KernelAndGradienti(r_i, r_j, smoothingData[i].h);
-                float4 kernel_ij_j = SplineKernel.KernelAndGradienti(r_i, r_j, smoothingData[j].h);
-                var kernel_ij_sym = (kernel_ij_i + kernel_ij_j) * 0.5f;
-                var ij = new ParticleInteraction
-                {
-                    Self = i,
-                    Other = j,
-                    KernelThis = kernel_ij_i,
-                    KernelOther = kernel_ij_j,
-                    KernelSymmetric = kernel_ij_sym,
-                    distance = distance,
-                };
-
-                // The only difference here is the derivatives which are now w.r.t. particle j's position
-                // for an isotropic and even kernel function it should be true that
-                // kernel_ji_sym = new float4( -kernel_ij_sym.xyz, kernel_ij_sym.w)
-                float4 kernel_ji_i = SplineKernel.KernelAndGradienti(r_j, r_i, smoothingData[i].h);
-                float4 kernel_ji_j = SplineKernel.KernelAndGradienti(r_j, r_i, smoothingData[j].h);
-                var kernel_ji_sym = (kernel_ji_i + kernel_ji_j) * 0.5f;
-                var ji = new ParticleInteraction
-                {
-                    Self = j,
-                    Other = i,
-                    KernelThis = kernel_ji_j,
-                    KernelOther = kernel_ji_i,
-                    KernelSymmetric = kernel_ji_sym,
-                    distance = distance,
-                };
-
-                // Only insert to data structures later steps use for iteration if there's
-                // a weight greater than zero for this pair. This saves every later calculation
-                // time in iteration.
-                if (kernel_ij_sym.w > 0.0f)
-                {
-                    // We're going to insert into the buffers of i and j a record represeting
-                    // The symmetrized kernel contribution of the other one
-
-                    // Particle i
-                    interactionsWriter.Write(ij);
-
-                    // Particle j
-                    interactionsWriter.Write(ji);
-                }
-#if RECORD_ALL_COLLISIONS
-            // TODO fixup Will need parallel queue system if particlequeuewriters works
-
-            // Reuse index from global order of collisions for when we record into ecb
-            // This means we can only deal with 2^30 interactions max rather than 2^31 :(
-            int index_i = index << 1;
-            int index_j = index_i + 1;
-
-            interactionDataWriter.AppendToBuffer(index_i, i, new ParticleCollision { Other = j , distance = math.length(r_i - r_j) });
-            interactionDataWriter.AppendToBuffer(index_j, j, new ParticleCollision { Other = i , distance = math.length(r_i - r_j) });
-#endif
-            }
-        }
-    }
 }

--- a/Assets/Scripts/Systems/ParticleAuthoring.cs
+++ b/Assets/Scripts/Systems/ParticleAuthoring.cs
@@ -1,6 +1,3 @@
-//#define RECORD_ALL_COLLISIONS
-//#define KERNEL_SYSTEM_EXP
-// Also in KernelSystem
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
@@ -89,9 +86,6 @@ public class ParticleAuthoring : MonoBehaviour, IConvertGameObjectToEntity
         entityManager.AddComponentData(prototype, new ParticlePressure());
         entityManager.AddComponentData(prototype, new ParticlePressureGrad());
         entityManager.AddBuffer<ParticleInteraction>(prototype);
-#if RECORD_ALL_COLLISIONS
-        entityManager.AddBuffer<ParticleCollision>(prototype);
-#endif
 
         // TODO: Explicitly run this creation on the main thread, avoid the obfuscation of a job
         //       This is being done as a parallel-for job with an entity command buffer

--- a/Assets/Scripts/Systems/PressureFieldSystem.cs
+++ b/Assets/Scripts/Systems/PressureFieldSystem.cs
@@ -10,7 +10,7 @@ using Unity.Burst;
 
 [BurstCompile]
 [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
-[UpdateAfter(typeof(KernelDataSystem))]
+[UpdateAfter(typeof(StepPhysicsWorld))]
 [UpdateAfter(typeof(DensityFieldSystem))]
 public class PressureFieldSystem : SystemBase
 {

--- a/Assets/Scripts/Util/SplineKernel.cs
+++ b/Assets/Scripts/Util/SplineKernel.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Unity.Burst;
 using Unity.Mathematics;
+using Unity.Transforms;
 
 
 [BurstCompile]
@@ -45,6 +46,16 @@ static class SplineKernel
     // It should always be true that Kernel(Kappa()*h, h) = 0.0f because of compactness
     // TODO: learn to write tests in unity!
     static public float Kappa() => 2.0f;
+
+    // Return true if the particles could interact at either of the given smoothing lengths
+    static public bool Interacts(float3 r_i, float3 r_j, float size_i, float size_j)
+    {
+        float3 displacement = (r_i - r_j);
+        float distanceSq = math.dot(displacement, displacement);
+        return 
+            (distanceSq < size_i * size_i * Kappa() * Kappa()) || 
+            (distanceSq < size_j * size_j * Kappa() * Kappa());
+    }
 
     static public float Kernel(float distance, float size)
     {

--- a/Assets/Scripts/Util/SplineKernel.cs
+++ b/Assets/Scripts/Util/SplineKernel.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
-using Unity.Burst;
 using Unity.Mathematics;
-using Unity.Transforms;
 
-
-[BurstCompile]
 static class SplineKernel
 {
     // Todo: Abstract this as an interface so caller can use generalized kernel and swap out kernel function
@@ -51,10 +47,9 @@ static class SplineKernel
     static public bool Interacts(float3 r_i, float3 r_j, float size_i, float size_j)
     {
         float3 displacement = (r_i - r_j);
+        float size = math.max(size_i, size_j);
         float distanceSq = math.dot(displacement, displacement);
-        return 
-            (distanceSq < size_i * size_i * Kappa() * Kappa()) || 
-            (distanceSq < size_j * size_j * Kappa() * Kappa());
+        return (distanceSq < size * size * Kappa() * Kappa()) ;
     }
 
     static public float Kernel(float distance, float size)

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,15 +1,16 @@
 {
   "dependencies": {
+    "com.unity.burst": "1.6.1",
     "com.unity.collab-proxy": "1.9.0",
     "com.unity.entities": "0.17.0-preview.42",
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.ide.visualstudio": "2.0.11",
+    "com.unity.ide.visualstudio": "2.0.12",
     "com.unity.ide.vscode": "1.2.4",
     "com.unity.physics": "file:../UpstreamPackages/com.unity.physics@0.6.0-preview.3",
     "com.unity.render-pipelines.universal": "11.0.0",
     "com.unity.rendering.hybrid": "0.11.0-preview.44",
     "com.unity.shadergraph": "11.0.0",
-    "com.unity.test-framework": "1.1.29",
+    "com.unity.test-framework": "1.1.30",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.5.6",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.5.6",
-      "depth": 1,
+      "version": "1.6.1",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.2.1"
@@ -62,7 +62,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -224,7 +224,7 @@
       }
     },
     "com.unity.test-framework": {
-      "version": "1.1.29",
+      "version": "1.1.30",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Base/Jobs/IJobParallelForDeferExtensionsPhysics.cs
+++ b/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Base/Jobs/IJobParallelForDeferExtensionsPhysics.cs
@@ -3,7 +3,7 @@ using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Jobs
 {
-    internal static class IJobParallelForDeferExtensionsPhysics
+    public static class IJobParallelForDeferExtensionsPhysics
     {
         unsafe public static JobHandle ScheduleUnsafeIndex0<T>(this T jobData, NativeArray<int> forEachCount, int innerloopBatchCount, JobHandle dependsOn = new JobHandle()) 
             where T : struct, IJobParallelForDefer

--- a/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Callbacks.cs
+++ b/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Callbacks.cs
@@ -11,6 +11,7 @@ namespace Unity.Physics
         // Callbacks that are invoked after each simulation phase (no callback needed after last phase)
         public enum Phase
         {
+            PostBroadphase,
             PostCreateDispatchPairs,
             PostCreateContacts,
             PostCreateContactJacobians,
@@ -18,7 +19,7 @@ namespace Unity.Physics
         }
 
         // this needs to match the number of phase values above
-        private static readonly int k_NumCallbacks = 4;
+        private static readonly int k_NumCallbacks = 5;
 
         public delegate JobHandle Callback(ref ISimulation simulation, ref PhysicsWorld world, JobHandle inputDeps);
 

--- a/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Scheduler.cs
+++ b/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Scheduler.cs
@@ -127,23 +127,23 @@ namespace Unity.Physics
         public struct SolverSchedulerInfo : IDisposable
         {
             // A structure which describes the number of items in a single phase
-            internal struct SolvePhaseInfo
+            public struct SolvePhaseInfo
             {
                 internal int DispatchPairCount; // The total number of pairs in this phase
                 internal int BatchSize; // The number of items per thread work item; at most, the number of pairs
-                internal int NumWorkItems; // The amount of "subtasks" of size BatchSize in this phase
-                internal int FirstWorkItemIndex; // The sum of NumWorkItems in all previous phases. Used for output native stream.
+                public int NumWorkItems; // The amount of "subtasks" of size BatchSize in this phase
+                public int FirstWorkItemIndex; // The sum of NumWorkItems in all previous phases. Used for output native stream.
                 internal int FirstDispatchPairIndex; // Index into the array of DispatchPairs for this phase.
             }
 
             [NoAlias]
-            internal NativeArray<SolvePhaseInfo> PhaseInfo;
+            public NativeArray<SolvePhaseInfo> PhaseInfo;
             [NoAlias]
             internal NativeArray<int> NumActivePhases;
             [NoAlias]
-            internal NativeArray<int> NumWorkItems;
+            public NativeArray<int> NumWorkItems;
 
-            internal int NumPhases => PhaseInfo.Length;
+            public int NumPhases => PhaseInfo.Length;
             internal static int CalculateNumWorkItems(NativeArray<SolvePhaseInfo> phaseInfos)
             {
                 int numWorkItems = 0;
@@ -169,7 +169,7 @@ namespace Unity.Physics
             }
 
             // For a given work item returns index into PhasedDispatchPairs and number of pairs to read.
-            internal int GetWorkItemReadOffset(int workItemIndex, out int pairReadCount)
+            public int GetWorkItemReadOffset(int workItemIndex, out int pairReadCount)
             {
                 SolvePhaseInfo phaseInfo = PhaseInfo[FindPhaseId(workItemIndex)];
 

--- a/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Scheduler.cs
+++ b/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Scheduler.cs
@@ -124,7 +124,7 @@ namespace Unity.Physics
 
         // A phased set of dispatch pairs used to schedule solver jobs and distribute work between them.
         [NoAlias]
-        internal struct SolverSchedulerInfo : IDisposable
+        public struct SolverSchedulerInfo : IDisposable
         {
             // A structure which describes the number of items in a single phase
             internal struct SolvePhaseInfo

--- a/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Simulation.cs
+++ b/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/Dynamics/Simulation/Simulation.cs
@@ -183,7 +183,7 @@ namespace Unity.Physics
     }
 
     // Temporary data created and destroyed during the step
-    internal struct StepContext
+    public struct StepContext
     {
         // Built by the scheduler. Groups body pairs into phases in which each
         // body appears at most once, so that the interactions within each phase can be solved
@@ -206,7 +206,7 @@ namespace Unity.Physics
         public JobHandle FinalSimulationJobHandle => m_StepHandles.FinalExecutionHandle;
         public JobHandle FinalJobHandle => JobHandle.CombineDependencies(FinalSimulationJobHandle, m_StepHandles.FinalDisposeHandle);
 
-        internal StepContext StepContext = new StepContext();
+        public StepContext StepContext = new StepContext();
 
         public CollisionEvents CollisionEvents => SimulationContext.CollisionEvents;
 

--- a/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/ECS/Base/Systems/IPhysicsSystem.cs
+++ b/UpstreamPackages/com.unity.physics@0.6.0-preview.3/Unity.Physics/ECS/Base/Systems/IPhysicsSystem.cs
@@ -3,7 +3,7 @@ using Unity.Jobs;
 namespace Unity.Physics.Systems
 {
     // Defines an interface for all internal physics systems
-    internal interface IPhysicsSystem
+    public interface IPhysicsSystem
     {
         void AddInputDependency(JobHandle inputDep);
 


### PR DESCRIPTION
Fast algorithm for updating kernel contributions starting from end of Broadphase
For 3000 SPH particles, this version runs in 6.5ms, a ~10x speedup. 

**Perf**
- On main prior to this branch, the same work takes 64ms. 
- There is an intermediate implementation on this branch (deleted in final) which used PhaseDispatchPairs and did the same work in 50ms.
- All measurements are wall-clock time from immediately after Broadphase to the point where all kernels are calculated and stored.

**Additions**
- New callback and data access to Physics so we do not need to wait for DispatchPairs sorting, and can bypass it for our particles. Physics default sorting is inefficient for the density of SPH collision graph.
- Algorithm proceeds in 3 phases:
  - Multi-threaded Filtering of pairs, which drops pairs where kernel will be zero, and forwards any collisions that are not SPH particles back to physics.
  - Single-threaded radix sorting of pairs by first particle and second particle
  - Multi-threaded calculation of kernel and gradient. Each thread only touches one particle, so it writes to the particle's DynamicBuffer component immediately.
- Burst Compiler directives, and various micro-optimizations
  